### PR TITLE
fix php8 compatibility in method_exists call

### DIFF
--- a/src/VariableDeflator.php
+++ b/src/VariableDeflator.php
@@ -17,7 +17,7 @@ class VariableDeflator
             return $arg->render(array());
         } else if ($arg instanceof Raw) {
             return (string)$arg;
-        } else if ($arg instanceof Exportable || method_exists($arg, '__get_state')) {
+        } else if ($arg instanceof Exportable || ((is_object($arg) || is_string($arg)) && method_exists($arg, '__get_state'))) {
             $class = get_class($arg);
             return $class . '::__set_state(' . var_export($arg->__get_state(), true) . ')';
         } else if (is_array($arg) || is_scalar($arg) || method_exists($arg, '__set_state')) {


### PR DESCRIPTION
fixes PHP8 compatibility issue I ran into when trying to build a phar from a c9s/CLIFramework project 